### PR TITLE
Add config option for disabling specific applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Settings are found in the `settings.ini` file. Do not rename that file. It shoul
 
 - `ignoreCpuTime`: (0 = disabled, 1 = enabled) Don't use the CPU frametime to adjust resolution.
 
+- `disabledApps`: Space-delimited list of OpenVR application keys that should be ignored for resolution adjustment. Steam games use the format steam.app.APPID, e.g. steam.app.438100 for VRChat and steam.app.620980 for Beat Saber.
+
 ## Building from source
 
 We assume that you already have Git and CMake installed.

--- a/settings.ini
+++ b/settings.ini
@@ -24,3 +24,4 @@ vramMonitorEnabled=1
 vramOnlyMode=0
 preferReprojection=0
 ignoreCpuTime=0
+disabledApps=

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,12 +102,14 @@ float getVramUsage(nvmlLib nvmlLibrary)
 	return (float)memoryInfo.used / (float)memoryInfo.total;
 }
 
-std::set<std::string> splitConfigValue(const std::string& val) {
+std::set<std::string> splitConfigValue(const std::string &val)
+{
 	std::set<std::string> set;
 	std::stringstream ss(val);
 	std::string word;
 
-	while (ss >> word) {
+	while (ss >> word)
+	{
 		set.insert(word);
 	}
 
@@ -159,16 +161,19 @@ long getCurrentTimeMillis()
 	return millis.count();
 }
 
-std::string getCurrentApplicationKey() {
+std::string getCurrentApplicationKey()
+{
 	char applicationKey[vr::k_unMaxApplicationKeyLength];
 
 	uint32_t processId = vr::VRApplications()->GetCurrentSceneProcessId();
-	if (processId == 0) {
+	if (processId == 0)
+	{
 		return "";
 	}
 
-	EVRApplicationError err = vr::VRApplications()->GetApplicationKeyByProcessId(processId, applicationKey,vr::k_unMaxApplicationKeyLength);
-	if (err != VRApplicationError_None) {
+	EVRApplicationError err = vr::VRApplications()->GetApplicationKeyByProcessId(processId, applicationKey, vr::k_unMaxApplicationKeyLength);
+	if (err != VRApplicationError_None)
+	{
 		return "";
 	}
 
@@ -411,7 +416,9 @@ int main(int argc, char *argv[])
 					// Reset to initialRes because CPU time fell below the threshold
 					newRes = initialRes;
 				}
-			} else if (isCurrentAppDisabled) {
+			}
+			else if (isCurrentAppDisabled)
+			{
 				// We've switched into an unsupported application, let's reset
 				newRes = initialRes;
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,6 +294,7 @@ int main(int argc, char *argv[])
 
 	// Initialize loop variables
 	long lastChangeTime = getCurrentTimeMillis();
+	bool isCurrentAppDisabled = false;
 	bool adjustResolution = true;
 	std::list<float> gpuTimes;
 	std::list<float> cpuTimes;
@@ -370,9 +371,12 @@ int main(int argc, char *argv[])
 		{
 			lastChangeTime = currentTime;
 
-			// Check that we're in a supported application
+			// Check if the SteamVR dashboard is open
 			bool inDashboard = vr::VROverlay()->IsDashboardVisible();
-			bool isCurrentAppDisabled = disabledApps.find(getCurrentApplicationKey()) != disabledApps.end();
+			// Check that we're in a supported application
+			std::string appKey = getCurrentApplicationKey();
+			isCurrentAppDisabled = disabledApps.find(appKey) != disabledApps.end() || appKey == "";
+			// Only adjust resolution if not in dashboard and in a supported application
 			adjustResolution = !inDashboard && !isCurrentAppDisabled;
 
 			if (adjustResolution)
@@ -506,7 +510,7 @@ int main(int argc, char *argv[])
 		attroff(A_BOLD);
 
 		// Resolution adjustment status
-		if (!adjustResolution)
+		if (!adjustResolution || isCurrentAppDisabled)
 		{
 			mvprintw(18, 0, "Resolution adjustment paused");
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,6 +289,7 @@ int main(int argc, char *argv[])
 
 	// Initialize loop variables
 	long lastChangeTime = getCurrentTimeMillis();
+	bool adjustResolution = true;
 	std::list<float> gpuTimes;
 	std::list<float> cpuTimes;
 
@@ -359,15 +360,15 @@ int main(int argc, char *argv[])
 		// Get VRAM usage
 		float vramUsage = getVramUsage(nvmlLibrary);
 
-		// Check that we're in a supported application
-		bool inDashboard = vr::VROverlay()->IsDashboardVisible();
-		bool isCurrentAppDisabled = disabledApps.find(getCurrentApplicationKey()) != disabledApps.end();
-		bool adjustResolution = !inDashboard && !isCurrentAppDisabled;
-
 		// Resolution handling
 		if (currentTime - resChangeDelayMs > lastChangeTime)
 		{
 			lastChangeTime = currentTime;
+
+			// Check that we're in a supported application
+			bool inDashboard = vr::VROverlay()->IsDashboardVisible();
+			bool isCurrentAppDisabled = disabledApps.find(getCurrentApplicationKey()) != disabledApps.end();
+			adjustResolution = !inDashboard && !isCurrentAppDisabled;
 
 			if (adjustResolution)
 			{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,7 +372,6 @@ int main(int argc, char *argv[])
 
 			if (adjustResolution)
 			{
-
 				// Adjust resolution
 				if ((averageCpuTime > minCpuTimeThreshold || vramOnlyMode))
 				{
@@ -412,12 +411,15 @@ int main(int argc, char *argv[])
 					// Reset to initialRes because CPU time fell below the threshold
 					newRes = initialRes;
 				}
+			} else if (isCurrentAppDisabled) {
+				// We've switched into an unsupported application, let's reset
+				newRes = initialRes;
+			}
 
-				if (newRes != lastRes)
-				{
-					// Sets the new resolution
-					vr::VRSettings()->SetFloat(vr::k_pch_SteamVR_Section, vr::k_pch_SteamVR_SupersampleScale_Float, newRes);
-				}
+			if (newRes != lastRes)
+			{
+				// Sets the new resolution
+				vr::VRSettings()->SetFloat(vr::k_pch_SteamVR_Section, vr::k_pch_SteamVR_SupersampleScale_Float, newRes);
 			}
 		}
 


### PR DESCRIPTION
This adds a new setting, `disabledApps`, that allows for people to exclude specific applications from resolution adjustment.
I've found this most helpful with Beat Saber, where while sometimes the frametime may be raised slightly, I still don't want dynamic resolution to trigger and cause more massive stutters.

The setting expects a space-delimited list of OpenVR application keys, e.g. `steam.app.438100` for VRChat, `steam.app.620980` for Beat Saber, etc.

I've done some testing locally with this and haven't noticed any issues. Let me know if you have any feedback or questions!